### PR TITLE
Refactored `init_DB` to async 

### DIFF
--- a/dbUtils.js
+++ b/dbUtils.js
@@ -1,5 +1,5 @@
 const sqlite3 = require('sqlite3').verbose();
-const fs = require('fs');
+const fs = require('fs').promises;
 
 const SCHEMA_FILE_PATH = 'schema.sql';
 
@@ -9,12 +9,21 @@ function connect_DB() {
 }
 
 // Function to initialize the database tables
-function init_DB() {
+async function init_DB() {
     try {
         let db = connect_DB();
-        const schema = fs.readFileSync('schema.sql', 'utf-8');
-        db.exec(schema);
-        db.close();
+        const schema = await fs.readFile(SCHEMA_FILE_PATH, 'utf-8');
+
+        await new Promise((resolve, reject) => {
+            db.exec(schema, (error) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve();
+                }
+                db.close();
+            });
+        });
     } catch (error) {
         console.log(error);
     }

--- a/tests/add_message.test.js
+++ b/tests/add_message.test.js
@@ -9,11 +9,10 @@ const { response } = require('../app');
 let agent;
 
 describe('Endpoint /add_message', () => {
-    before(function () {
+    before(async function () {
         agent = request.agent(app);
-        init_DB();
-    })
-    it('should succesfully add a message', async () => {
+        await init_DB();
+
         const register_response = await agent
             .post('/register')
             .send({
@@ -29,7 +28,9 @@ describe('Endpoint /add_message', () => {
                 username: 'test',
                 password: 'test'
             });
+    });
 
+    it('should succesfully add a message', async () => {
         const response = await agent
             .post('/add_message')
             .send({

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -9,20 +9,20 @@ const { response } = require('../app');
 let agent;
 
 describe('Endpoint /login', () => {
-    before(function () {
+    before(async function () {
         agent = request.agent(app);
-        init_DB();
+        await init_DB();
+        await agent
+            .post('/register')
+            .send({
+                username: 'someUser',
+                password: 'default',
+                password2: 'default',
+                email: 'someUser@email.com'
+            });
     });
 
     it('should successfully login a registered user', async () => { 
-        const register_response = await agent
-        .post('/register')
-        .send({
-            username: 'someUser',
-            password: 'default',
-            password2: 'default',
-            email: 'someUser@email.com'
-        });
         // attempt login that should be successful
         const response = await agent
             .post('/login')
@@ -35,15 +35,6 @@ describe('Endpoint /login', () => {
     });
 
     it('should fail due to wrong password', async () => {
-        const register_response = await agent
-        .post('/register')
-        .send({
-            username: 'someUser',
-            password: 'default',
-            password2: 'default',
-            email: 'someUser@email.com'
-        });
-
         const response = await agent
             .post('/login')
             .send({

--- a/tests/register.test.js
+++ b/tests/register.test.js
@@ -10,11 +10,12 @@ let agent;
 
 
 describe('Endpoint /register', () => {
-    before(function () {
+    beforeEach(async function () {
         // Setup Express app before each test and reset database
         agent = request.agent(app);
-        init_DB();
-    })
+        await init_DB();
+    });
+    
     it('should register a user', async () => {
         const response = await agent
             .post('/register')

--- a/tests/timeline.test.js
+++ b/tests/timeline.test.js
@@ -17,7 +17,7 @@ describe('Timeline', () => {
 
     before(async function () {
         agent = request.agent(app);
-        init_DB();
+        await init_DB();
 
         // register dummy accounts
         await agent.post('/register').send({


### PR DESCRIPTION
Rewrote `init_DB` to use a promise such that the instantiation of the DB can be awaited. Affected tests are changed such that they now shouldn't fail tests that should pass. 

This should close #2
 
```javascript
async function init_DB() {
    try {
        let db = connect_DB();
        const schema = await fs.readFile(SCHEMA_FILE_PATH, 'utf-8');

        await new Promise((resolve, reject) => {
            db.exec(schema, (error) => {
                if (error) {
                    reject(error);
                } else {
                    resolve();
                }
                db.close();
            });
        });
    } catch (error) {
        console.log(error);
    }
}
```